### PR TITLE
Fixes missing backgrounds and item tooltips

### DIFF
--- a/src/base/gcewing/sg/BaseGui.java
+++ b/src/base/gcewing/sg/BaseGui.java
@@ -71,13 +71,14 @@ public class BaseGui {
             root.layout();
         }
         
-//      @Override
-//      public void drawScreen(int par1, int par2, float par3) {
-//          resetColor();
-//          textColor = defaultTextColor;
-//          textShadow = false;
-//          super.drawScreen(par1, par2, par3);
-//      }
+        /**
+         * Draws the screen and all the components in it.
+         */
+        public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+            this.drawDefaultBackground();
+            super.drawScreen(mouseX, mouseY, partialTicks);
+            this.renderHoveredToolTip(mouseX, mouseY);
+        }
         
         @Override
         protected void drawGuiContainerBackgroundLayer(float f, int mouseX, int mouseY) {

--- a/src/mod/gcewing/sg/DHDScreen.java
+++ b/src/mod/gcewing/sg/DHDScreen.java
@@ -234,6 +234,9 @@ public class DHDScreen extends SGScreen {
         }
         glPopAttrib();
     }
+    
+    @Override
+    public void drawDefaultBackground() {}
 
     void drawBackgroundImage() {
         bindTexture(SGCraft.mod.resourceLocation("textures/gui/dhd_gui.png"));


### PR DESCRIPTION
This adds in the tooltips and greyed out backgrounds for the not-DHD guis.
Kept the lack of background for the DHD gui.

To Fix JEI stuff while dialing, the DHD gui might need to be changed to a guiScreen instead of a guicontainer.