### PR TITLE
RF consume problem

### DIFF
--- a/src/mod/gcewing/sg/tileentity/SGPowerTE.java
+++ b/src/mod/gcewing/sg/tileentity/SGPowerTE.java
@@ -59,7 +59,7 @@ public class SGPowerTE extends PowerTE implements IEnergyStorage {
 
     @Override
     public int receiveEnergy(int maxReceive, boolean simulate) {
-        int energyReceived = Math.min((int)(energyMax - energyBuffer),maxReceive);
+        int energyReceived = Math.min((int)Math.floor(energyMax - energyBuffer),maxReceive);
         if (!simulate)
             energyBuffer += energyReceived;
         markChanged();
@@ -68,32 +68,22 @@ public class SGPowerTE extends PowerTE implements IEnergyStorage {
 
     @Override
     public int extractEnergy(int maxExtract, boolean simulate) {
-        int energyExtracted = Math.min((int) energyBuffer, maxExtract);
-        if (!simulate)
-            energyBuffer -= energyExtracted;
-        markChanged();
-        return energyExtracted;
+        return 0;
     }
 
     @Override
     public int getEnergyStored() {
-        if (energyBuffer >= Integer.MAX_VALUE) {
-            return Integer.MAX_VALUE;
-        }
-        return (int) energyBuffer;
+        return (int) Math.floor(energyBuffer);
     }
 
     @Override
     public int getMaxEnergyStored() {
-        if (energyMax >= Integer.MAX_VALUE) {
-            return Integer.MAX_VALUE;
-        }
-        return (int) energyMax;
+        return (int) Math.floor(energyMax);
     }
 
     @Override
     public boolean canExtract() {
-        return true;
+        return false;
     }
 
     @Override

--- a/src/mod/gcewing/sg/tileentity/SGPowerTE.java
+++ b/src/mod/gcewing/sg/tileentity/SGPowerTE.java
@@ -77,11 +77,17 @@ public class SGPowerTE extends PowerTE implements IEnergyStorage {
 
     @Override
     public int getEnergyStored() {
+        if (energyBuffer >= Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
         return (int) energyBuffer;
     }
 
     @Override
     public int getMaxEnergyStored() {
+        if (energyMax >= Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
         return (int) energyMax;
     }
 

--- a/src/mod/gcewing/sg/tileentity/SGPowerTE.java
+++ b/src/mod/gcewing/sg/tileentity/SGPowerTE.java
@@ -11,16 +11,11 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.energy.CapabilityEnergy;
-import net.minecraftforge.energy.EnergyStorage;
 import net.minecraftforge.energy.IEnergyStorage;
 
 import javax.annotation.Nullable;
 
 public class SGPowerTE extends PowerTE implements IEnergyStorage {
-
-    private int maxInput = 10000;
-    private int maxOutput = 10000;
-    private EnergyStorage storage = new EnergyStorage(SGCraft.FPMaxEnergyBuffer, maxInput, maxOutput);
 
     public SGPowerTE() {
         super(SGCraft.FPMaxEnergyBuffer, SGCraft.FPPerSGEnergyUnit);
@@ -39,24 +34,10 @@ public class SGPowerTE extends PowerTE implements IEnergyStorage {
     @Override
     public void readContentsFromNBT(NBTTagCompound nbttagcompound) {
         super.readContentsFromNBT(nbttagcompound);
-        if (nbttagcompound.hasKey("capacity")) {
-            int capacity = nbttagcompound.getInteger("capacity");
-            int energy = nbttagcompound.getInteger("energy");
-            storage = new EnergyStorage(capacity, this.maxInput, this.maxOutput, energy);
-        }
-
         if (SGCraft.forceFPCfgUpdate) {
             energyMax = SGCraft.FPMaxEnergyBuffer;
             energyPerSGEnergyUnit = SGCraft.FPPerSGEnergyUnit;
-            storage = new EnergyStorage((int)energyMax, this.maxInput, maxOutput );
         }
-    }
-
-    @Override
-    public void writeContentsToNBT(NBTTagCompound nbttagcompound) {
-        super.writeContentsToNBT(nbttagcompound);
-        nbttagcompound.setInteger("capacity", storage.getMaxEnergyStored());
-        nbttagcompound.setInteger("energy", storage.getEnergyStored());
     }
 
     @Override
@@ -78,43 +59,44 @@ public class SGPowerTE extends PowerTE implements IEnergyStorage {
 
     @Override
     public int receiveEnergy(int maxReceive, boolean simulate) {
-        int result = storage.receiveEnergy(maxReceive, simulate);
-        energyBuffer = storage.getEnergyStored();
+        int energyReceived = Math.min((int)(energyMax - energyBuffer),maxReceive);
+        if (!simulate)
+            energyBuffer += energyReceived;
         markChanged();
-
-        return result;
+        return energyReceived;
     }
 
     @Override
     public int extractEnergy(int maxExtract, boolean simulate) {
-        int result = storage.extractEnergy(maxExtract, simulate);
-        energyBuffer = storage.getEnergyStored();
+        int energyExtracted = Math.min((int) energyBuffer, maxExtract);
+        if (!simulate)
+            energyBuffer -= energyExtracted;
         markChanged();
-
-        return result;
+        return energyExtracted;
     }
 
     @Override
     public int getEnergyStored() {
-        return storage.getEnergyStored();
+        return (int) energyBuffer;
     }
 
     @Override
     public int getMaxEnergyStored() {
-        return storage.getMaxEnergyStored();
+        return (int) energyMax;
     }
 
     @Override
     public boolean canExtract() {
-        return storage.canExtract();
+        return true;
     }
 
     @Override
     public boolean canReceive() {
-        return storage.canReceive();
+        return true;
     }
 
-    @Override public double totalAvailableEnergy() {
+    @Override
+    public double totalAvailableEnergy() {
         return energyBuffer;
     }
 }


### PR DESCRIPTION
I`m creating a pull request to solve the problem that the portal don't consume RF.

--the problem---
There is 2 places to storage the energy,
one is the energyBuffer
other is EnergyStorage.

When the method drawEnergyDouble from PowerTE is called, the energy is extracted from energyBuffer
but is not updated to EnergyStorage class.

The method receiveEnergy, call this:
   int result = storage.receiveEnergy(maxReceive, simulate);
but the EnergyStorage it's always full, so the result is always zero, and don't extract the energy from the conection.
and you update the buffer with this line:
 energyBuffer = storage.getEnergyStored();

The only way to consume energy is when you connect for the first time.


I removed the EnergyStorage because there is no reason to store in 2 different places the energy.
