### PR TITLE
Fix TileEntity dialing unloading remote gate.

### DIFF
--- a/src/base/gcewing/sg/BaseTileEntity.java
+++ b/src/base/gcewing/sg/BaseTileEntity.java
@@ -34,6 +34,7 @@ public class BaseTileEntity extends TileEntity
     public byte side, turn;
     public Ticket chunkTicket;
     protected boolean updateChunk;
+    public boolean isPending = false;
 
     public int getX() {return pos.getX();}
     public int getY() {return pos.getY();}
@@ -198,8 +199,13 @@ public class BaseTileEntity extends TileEntity
 
     @Override
     public void invalidate() {
-        releaseChunkTicket();
-        super.invalidate();
+        if (!isPending) {
+            releaseChunkTicket();
+            //System.out.println("Invalidated TE: " + this);
+            super.invalidate();
+        }
+
+        isPending = false;
     }
     
     public void releaseChunkTicket() {

--- a/src/mod/gcewing/sg/features/cc/CCSGPeripheral.java
+++ b/src/mod/gcewing/sg/features/cc/CCSGPeripheral.java
@@ -36,7 +36,7 @@ public class CCSGPeripheral implements IPeripheral {
         
         new SGMethod("energyToDial", 1) {
             Object[] call(SGInterfaceTE te, Object[] args) {
-                return new Object[] {te.ciEnergyToDial((String)args[0])};
+                return new Object[] {te.ciEnergyToDial((String)args[0], false)};
             }
         },
         
@@ -54,7 +54,7 @@ public class CCSGPeripheral implements IPeripheral {
         
         new SGMethod("dial", 1) {
             Object[] call(SGInterfaceTE te, Object[] args) {
-                te.ciDial((String)args[0]);
+                te.ciDial((String)args[0], false);
                 return null;
             }
         },

--- a/src/mod/gcewing/sg/features/oc/OCInterfaceTE.java
+++ b/src/mod/gcewing/sg/features/oc/OCInterfaceTE.java
@@ -101,7 +101,7 @@ public class OCInterfaceTE extends SGInterfaceTE
     
     @Callback
     public Object[] energyToDial(Context ctx, Arguments args) {
-        try {return new Object[]{ciEnergyToDial(args.checkString(0))};}
+        try {return new Object[]{ciEnergyToDial(args.checkString(0), true)};}
         catch (Exception e) {return failure(e);}
     }
     
@@ -119,7 +119,7 @@ public class OCInterfaceTE extends SGInterfaceTE
     
     @Callback
     public Object[] dial(Context ctx, Arguments args) {
-        try {ciDial(args.checkString(0)); return success;}
+        try {ciDial(args.checkString(0), true); return success;}
         catch (Exception e) {return failure(e);}
     }
     

--- a/src/mod/gcewing/sg/features/pdd/network/PddNetworkHandler.java
+++ b/src/mod/gcewing/sg/features/pdd/network/PddNetworkHandler.java
@@ -89,7 +89,7 @@ public class PddNetworkHandler extends SGChannel {
             if (setting == 1) { // Connect / Dial / Double Click
                 if (!localGate.isConnected()) {
                     if (localGate.allowGateAccess(player.getName()) || isPermissionsAdmin) {
-                        localGate.connect(destination, player, false);
+                        localGate.connect(destination, player, false, false);
                     }
                 }
             }

--- a/src/mod/gcewing/sg/tileentity/SGBaseTE.java
+++ b/src/mod/gcewing/sg/tileentity/SGBaseTE.java
@@ -963,7 +963,7 @@ public class SGBaseTE extends BaseTileInventory implements ITickable, LoopingSou
         if (address.length() > 0) {
             DHDTE te = getLinkedControllerTE();
             if (te != null) {
-                if (connect(address, player, false) != null) {
+                if (connect(address, player, false, false) != null) {
                     numEngagedChevrons = 0;
                     markChanged();
                 }
@@ -1004,7 +1004,7 @@ public class SGBaseTE extends BaseTileInventory implements ITickable, LoopingSou
     // Connect Here!!!
     // *************************************
 
-    public String connect(String address, EntityPlayer player, boolean ccInterface) {
+    public String connect(String address, EntityPlayer player, boolean ccInterface, boolean pending) {
         // Note:  if player is null when introduced to this method, then it usually indicates a CI attempting to dial.
         // Note:  ccInterface == true so it stops the immediate chevron lock if a ccInterface is the one doing the dialing.
         debugEnergyUse = false;
@@ -1029,7 +1029,7 @@ public class SGBaseTE extends BaseTileInventory implements ITickable, LoopingSou
 
         SGBaseTE targetGate;
         try {
-            targetGate = SGAddressing.findAddressedStargate(address, world);
+            targetGate = SGAddressing.findAddressedStargate(address, world, pending);
         } catch (SGAddressing.AddressingError e) {
             return diallingFailure(player, e.getMessage());
         }
@@ -1517,7 +1517,7 @@ public class SGBaseTE extends BaseTileInventory implements ITickable, LoopingSou
             this.numEngagedChevrons = enteredAddress.length();
 
             if (last) {
-                String value = connect(address, player, false);
+                String value = connect(address, player, false, false);
 
                 if (value != null) {
                     this.clearIdleConnection();
@@ -1532,7 +1532,7 @@ public class SGBaseTE extends BaseTileInventory implements ITickable, LoopingSou
         String randomAddress = GeneratorAddressRegistry.randomAddress(world, this.homeAddress, new Random());
         if (randomAddress != null) {
             if (this.allowOutgoingAddress(randomAddress, this.defaultAllowOutgoing)) {
-                SGBaseTE malfunctionDestinationGate = SGAddressing.findAddressedStargate(randomAddress, world);
+                SGBaseTE malfunctionDestinationGate = SGAddressing.findAddressedStargate(randomAddress, world, false);
                 if (malfunctionDestinationGate != null) {
                     if (malfunctionDestinationGate.allowIncomingAddress(this.homeAddress, malfunctionDestinationGate.defaultAllowIncoming)) {
                         this.getConnectedStargateTE().clearConnection();

--- a/src/mod/gcewing/sg/tileentity/SGInterfaceTE.java
+++ b/src/mod/gcewing/sg/tileentity/SGInterfaceTE.java
@@ -83,11 +83,11 @@ public class SGInterfaceTE extends BaseTileEntity {
         return te != null ? te.availableEnergy() : 0;
     }
     
-    public double ciEnergyToDial(String address) {
+    public double ciEnergyToDial(String address, boolean pending) {
         SGBaseTE te = requireBaseTE();
         try {
             address = SGAddressing.normalizeAddress(address);
-            SGBaseTE dte = SGAddressing.findAddressedStargate(address, te.getWorld());
+            SGBaseTE dte = SGAddressing.findAddressedStargate(address, te.getWorld(), pending);
             if (dte == null)
                 throw new IllegalArgumentException("unknownAddress");
             double distanceFactor = dte.distanceFactorForCoordDifference(te, dte);
@@ -116,7 +116,7 @@ public class SGInterfaceTE extends BaseTileEntity {
         }
     }
     
-    public void ciDial(String address) {
+    public void ciDial(String address, boolean pending) {
         SGBaseTE te = requireBaseTE();
 //         try {
 //             address = SGAddressing.normalizedRelativeAddress(address, te.getHomeAddress());
@@ -126,7 +126,7 @@ public class SGInterfaceTE extends BaseTileEntity {
 //         }
         address = SGAddressing.normalizeAddress(address);
         //System.out.printf("SGBaseTE.ciDial: dialling symbols %s\n", address);
-        String error = te.connect(address, null, true);
+        String error = te.connect(address, null, true, pending);
         if (error != null)
             throw new IllegalArgumentException(error);
     }

--- a/src/mod/gcewing/sg/util/SGAddressing.java
+++ b/src/mod/gcewing/sg/util/SGAddressing.java
@@ -26,6 +26,7 @@
 
 package gcewing.sg.util;
 
+import gcewing.sg.BaseTileEntity;
 import gcewing.sg.BaseUtils;
 import gcewing.sg.tileentity.SGBaseTE;
 import net.minecraft.world.World;
@@ -181,7 +182,7 @@ public class SGAddressing {
         return longToSymbols(c, numCoordSymbols) + intToSymbols(d, numDimensionSymbols);
     }
     
-    public static SGBaseTE findAddressedStargate(String address, World fromWorld) throws AddressingError {
+    public static SGBaseTE findAddressedStargate(String address, World fromWorld, boolean pending) throws AddressingError {
         if (debugAddressing)
             System.out.printf("SGAddressing.findAddressedStargate: %s\n", address);
         validateAddress(address);
@@ -205,32 +206,34 @@ public class SGAddressing {
                 System.out.printf("SGAddressing.findAddressedStargate: d = %s dimension = %s\n",
                     d, dm);
             if (dm != null)
-                te = getBaseTE(chunkX, chunkZ, dm);
+                te = getBaseTE(chunkX, chunkZ, dm, pending);
             if (te == null) {
                 // Try old interpretation of dimension symbols
                 int dimOld = minDirectDimension + hash(d, qdOld, mdOld);
                 if (debugAddressing)
                     System.out.printf("SGAddressing.findAddressedStargate: Trying dimension = %s\n",
                         dimOld);
-                te = getBaseTE(chunkX, chunkZ, dimOld);
+                te = getBaseTE(chunkX, chunkZ, dimOld, pending);
             }
         }
         else {
             // Relative address
             int dimension = fromWorld.provider.getDimension();
-            te = getBaseTE(chunkX, chunkZ, dimension);
+            te = getBaseTE(chunkX, chunkZ, dimension, pending);
         }
         return te;
     }
     
-    protected static SGBaseTE getBaseTE(int chunkX, int chunkZ, int dimension) {
+    protected static SGBaseTE getBaseTE(int chunkX, int chunkZ, int dimension, boolean pending) {
         World toWorld = getWorld(dimension);
         if (toWorld != null) {
             Chunk chunk = toWorld.getChunk(chunkX, chunkZ);
             if (chunk != null)
                 for (Object te : chunk.getTileEntityMap().values()) {
-                    if (te instanceof SGBaseTE)
-                        return (SGBaseTE)te;
+                    if (te instanceof SGBaseTE) {
+                        ((SGBaseTE) te).isPending = pending;
+                        return (SGBaseTE) te;
+                    }
                 }
         }
         return null;


### PR DESCRIPTION
So OpenComputers/etc trigger an interesting flaw in how SGCraft performs
remote dialing. SGCraft relies on loading the chunk of the remote gate
to grab that gate (The TE) so it can tell the remote to start dialing
(as is canon). Vanilla has a provision that any Tile Entities that are
added as a result of another Tile Entities' tick are "queued" to be
added at the end of that same tick. SGBaseTE of the remote gate keeps a
Chunk ticket open with MinecraftForge which simply tells Forge to disallow
Vanilla from unloading the chunk.

Phew...now why this is important is because of what happens when the
pending Tile Entities are proceessed at the end of that tick. Since the
source gate triggered the Chunk to load, that Chunk has it's Tile
Entities. World does not though. When World goes to add those pending
Tile Entities, it is effectively adding the same Tile Entity reference
back to the Chunk (that it already has). Chunk detects this and calls
invalidate() on the Tile Entity. As stated above, SGBaseTE keeps a Chunk
ticket and hands back that ticket to Forge during invalidate...

As you can see, this is a fun Vanilla "gotcha". Vanilla MUST queue the
Tile Entities added during Tile Entity ticks else it'll get a Concurrent
Modification Exception.

So what do we do?

Barring re-writing the structure of the mod to store chunk tickets
outside the remote gate's Tile Entity OR change the dialing sequence to
not require that Tile Entity right away, we'll apply more of Dockter's
famous duct tape.

I have added a "pending" flag to the connect sequence of events. If this
is as a result of anything BUT OpenComputers then it'll be false. If it
is, it'll be true. If this flag is set to true, we disregard the next
invalidate call (which will be the faulty re-set of the reference from
above).

That said, this isn't a 100% fix. This can still happen but frankly it now acts as an old car. Typically you run the computer command a second time and it'll work. Again, this needs a re-write for a permanent fix...

Signed-off-by: Chris Sanders <zidane@spongepowered.org>