### PR TITLE
Added SGMergeEvent when a Stargate is merged

### DIFF
--- a/src/mod/gcewing/sg/event/SGMergeEvent.java
+++ b/src/mod/gcewing/sg/event/SGMergeEvent.java
@@ -1,0 +1,56 @@
+package gcewing.sg.event;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.common.MinecraftForge;
+
+public class SGMergeEvent extends Event {
+
+    /*
+     Private because the event should be read-only - including both the gatePosition and address
+     in case changes are made to gate address generation
+     */
+    private final String worldName;
+    private final BlockPos gatePosition;
+    private final String address;
+    private final boolean merged;
+    private final World world;
+
+    /**
+     * Fired when a Stargate is merged or unmerged (the multiblock structure is completed or broken)
+     */
+    public SGMergeEvent(String worldName, String address, boolean merged, BlockPos gatePosition, World world) {
+        this.worldName = worldName;
+        this.gatePosition = gatePosition;
+        this.address = address;
+        this.merged = merged;
+        this.world = world;
+    }
+
+    public static SGMergeEvent fireEvent(String worldName, String address, boolean merged, BlockPos gatePosition, World world) {
+        SGMergeEvent event = new SGMergeEvent(worldName, address, merged, gatePosition, world);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public String getWorldName() {
+        return worldName;
+    }
+
+    public BlockPos getGatePosition() {
+        return gatePosition;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public boolean isMerged() {
+        return this.merged;
+    }
+
+    public World getWorld() {
+        return world;
+    }
+}

--- a/src/mod/gcewing/sg/event/SGMergeEvent.java
+++ b/src/mod/gcewing/sg/event/SGMergeEvent.java
@@ -11,7 +11,6 @@ public class SGMergeEvent extends Event {
      Private because the event should be read-only - including both the gatePosition and address
      in case changes are made to gate address generation
      */
-    private final String worldName;
     private final BlockPos gatePosition;
     private final String address;
     private final boolean merged;
@@ -20,22 +19,17 @@ public class SGMergeEvent extends Event {
     /**
      * Fired when a Stargate is merged or unmerged (the multiblock structure is completed or broken)
      */
-    public SGMergeEvent(String worldName, String address, boolean merged, BlockPos gatePosition, World world) {
-        this.worldName = worldName;
+    public SGMergeEvent(String address, boolean merged, BlockPos gatePosition, World world) {
         this.gatePosition = gatePosition;
         this.address = address;
         this.merged = merged;
         this.world = world;
     }
 
-    public static SGMergeEvent fireEvent(String worldName, String address, boolean merged, BlockPos gatePosition, World world) {
-        SGMergeEvent event = new SGMergeEvent(worldName, address, merged, gatePosition, world);
+    public static SGMergeEvent fireEvent(String address, boolean merged, BlockPos gatePosition, World world) {
+        SGMergeEvent event = new SGMergeEvent(address, merged, gatePosition, world);
         MinecraftForge.EVENT_BUS.post(event);
         return event;
-    }
-
-    public String getWorldName() {
-        return worldName;
     }
 
     public BlockPos getGatePosition() {

--- a/src/mod/gcewing/sg/tileentity/SGBaseTE.java
+++ b/src/mod/gcewing/sg/tileentity/SGBaseTE.java
@@ -833,7 +833,7 @@ public class SGBaseTE extends BaseTileInventory implements ITickable, LoopingSou
                 if (logStargateEvents) {
                     log.info(String.format("STARGATE %s %s %s %s", action, name, pos, address));
                 }
-                SGMergeEvent.fireEvent(name, this.homeAddress, isMerged, this.pos, getWorld());
+                SGMergeEvent.fireEvent(this.homeAddress, isMerged, this.pos, getWorld());
                 if (state) {
                     GeneralAddressRegistry.addAddress(world, this.homeAddress);
                 } else {

--- a/src/mod/gcewing/sg/tileentity/SGBaseTE.java
+++ b/src/mod/gcewing/sg/tileentity/SGBaseTE.java
@@ -16,6 +16,7 @@ import gcewing.sg.BaseBlockUtils;
 import gcewing.sg.BaseConfiguration;
 import gcewing.sg.BaseTileInventory;
 import gcewing.sg.BaseUtils;
+import gcewing.sg.event.SGMergeEvent;
 import gcewing.sg.features.ic2.zpm.modulehub.ZpmHubTE;
 import gcewing.sg.features.zpm.console.ZpmConsoleTE;
 import gcewing.sg.generator.GeneratorAddressRegistry;
@@ -832,6 +833,7 @@ public class SGBaseTE extends BaseTileInventory implements ITickable, LoopingSou
                 if (logStargateEvents) {
                     log.info(String.format("STARGATE %s %s %s %s", action, name, pos, address));
                 }
+                SGMergeEvent.fireEvent(name, this.homeAddress, isMerged, this.pos, getWorld());
                 if (state) {
                     GeneralAddressRegistry.addAddress(world, this.homeAddress);
                 } else {


### PR DESCRIPTION
Event will trigger when the setMerged method is called for a stargate base. For now, not using this for anything in the base mod itself, but having this will make it easier for other modders to react to a Stargate being created. Doesn't directly address any open issue, but will make addressing several easier in the future.

Implemented by adding a new class extending Forge's base Event,  and registering it to the normal Forge event bus.
Event exposes:
* The address of the gate that was just created or removed
* A boolean indicating whether the gate was created (true) or removed (false)
* A BlockPos which points at the Stargate base block's position
* A World - whichever World the gate was made/destroyed in.

I've got a working example of using this to do a variety of things (generate address loot, list and teleport to gates) in another project (https://github.com/bsixel/etheralt-pack-utils) but since I was unsure how you'd prefer the loot and data storage be handled, I kept it separate. If that looks reasonable I can move the storage and loot portion to this mod in another PR.